### PR TITLE
Fix misreferenced NFT image

### DIFF
--- a/data/copiaiatalicum1918.toml
+++ b/data/copiaiatalicum1918.toml
@@ -12,7 +12,7 @@ pero cargada con intención y mirada.
 Hoy no representa un imperio,
 sino un recuerdo hecho NFT.
 Único. Inmutable. AnimaArgenta Vault."""
-image = "https://animaargenta.com/nfts/ITALICUM1918/img/compuesta.png"
+image = "https://animaargenta.com/nfts/copiaiatalicum1918/front.png"
 is_unlimited = false
 is_asset_anchored = false
 display_decimals = 0


### PR DESCRIPTION
## Summary
- correct `copiaiatalicum1918` metadata to use the actual NFT image path

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_b_68473be482a8832680d8a5f147b2e6d2