### PR TITLE
Ensure issuer text wraps within history cards

### DIFF
--- a/nfts/bolivar1936/index.html
+++ b/nfts/bolivar1936/index.html
@@ -74,11 +74,20 @@
     }
     .meta p {
       margin: 0.3rem 0;
+      display: flex;
+      flex-wrap: wrap;
+      column-gap: 0.4rem;
+      row-gap: 0.2rem;
+    }
+    .meta p strong {
+      color: #fff;
+      flex: 0 0 auto;
+    }
+    .meta-value {
+      flex: 1 1 auto;
+      min-width: 0;
       word-break: break-all;
       overflow-wrap: anywhere;
-    }
-    .meta strong {
-      color: #fff;
     }
     @media (max-width: 700px) {
       .ficha {
@@ -109,12 +118,12 @@
       No buscaba fama… buscaba verdad.
     </div>
     <div class="meta">
-      <p><strong>Código:</strong> BOLIVAR1936</p>
-      <p><strong>Emisor:</strong> GDHWACVGTT2W467AYCGYI3PVBXSA6QBJTGMA3QCRGUUQS5ZKR5PUPYGZ</p>
-      <p><strong>Condiciones:</strong> NFT único. Emisión bloqueada. No reemitible.</p>
-      <p><strong>Origen:</strong> Mercatino di Verona</p>
-      <p><strong>Fecha de hallazgo:</strong> 2024-12-12</p>
-      <p><strong>Estado:</strong> Desgastada, pero completa</p>
+      <p><strong>Código:</strong><span class="meta-value">BOLIVAR1936</span></p>
+      <p><strong>Emisor:</strong><span class="meta-value">GDHWACVGTT2W467AYCGYI3PVBXSA6QBJTGMA3QCRGUUQS5ZKR5PUPYGZ</span></p>
+      <p><strong>Condiciones:</strong><span class="meta-value">NFT único. Emisión bloqueada. No reemitible.</span></p>
+      <p><strong>Origen:</strong><span class="meta-value">Mercatino di Verona</span></p>
+      <p><strong>Fecha de hallazgo:</strong><span class="meta-value">2024-12-12</span></p>
+      <p><strong>Estado:</strong><span class="meta-value">Desgastada, pero completa</span></p>
     </div>
   </div>
 </body>

--- a/nfts/bolivar1936/index.html
+++ b/nfts/bolivar1936/index.html
@@ -65,10 +65,6 @@
       text-align: center;
       color: #ccc;
     }
-    .meta p {
-  word-break: break-all;
-  overflow-wrap: anywhere;
-}
     .meta {
       font-size: 0.9rem;
       background: #181818;
@@ -78,6 +74,8 @@
     }
     .meta p {
       margin: 0.3rem 0;
+      word-break: break-all;
+      overflow-wrap: anywhere;
     }
     .meta strong {
       color: #fff;

--- a/nfts/copiaiatalicum1918/index.html
+++ b/nfts/copiaiatalicum1918/index.html
@@ -47,6 +47,17 @@
     }
     .meta p {
       margin: 0.3rem 0;
+      display: flex;
+      flex-wrap: wrap;
+      column-gap: 0.4rem;
+      row-gap: 0.2rem;
+    }
+    .meta p strong {
+      flex: 0 0 auto;
+    }
+    .meta-value {
+      flex: 1 1 auto;
+      min-width: 0;
       word-break: break-all;
       overflow-wrap: anywhere;
     }
@@ -63,12 +74,12 @@
       No buscaba fama… buscaba verdad.
     </div>
     <div class="meta">
-      <p><strong>Código:</strong> BOLIVAR1936</p>
-      <p><strong>Emisor:</strong> GDHWACVGTT2W467AYCGYI3PVBXSA6QBJTGMA3QCRGUUQS5ZKR5PUPYGZ</p>
-      <p><strong>Condiciones:</strong> NFT único. Emisión bloqueada. No reemitible.</p>
-      <p><strong>Origen:</strong> Mercatino di Verona</p>
-      <p><strong>Fecha de hallazgo:</strong> 2024-12-12</p>
-      <p><strong>Estado:</strong> Desgastada, pero completa</p>
+      <p><strong>Código:</strong><span class="meta-value">BOLIVAR1936</span></p>
+      <p><strong>Emisor:</strong><span class="meta-value">GDHWACVGTT2W467AYCGYI3PVBXSA6QBJTGMA3QCRGUUQS5ZKR5PUPYGZ</span></p>
+      <p><strong>Condiciones:</strong><span class="meta-value">NFT único. Emisión bloqueada. No reemitible.</span></p>
+      <p><strong>Origen:</strong><span class="meta-value">Mercatino di Verona</span></p>
+      <p><strong>Fecha de hallazgo:</strong><span class="meta-value">2024-12-12</span></p>
+      <p><strong>Estado:</strong><span class="meta-value">Desgastada, pero completa</span></p>
     </div>
   </div>
 </body>

--- a/nfts/copiaiatalicum1918/index.html
+++ b/nfts/copiaiatalicum1918/index.html
@@ -47,6 +47,8 @@
     }
     .meta p {
       margin: 0.3rem 0;
+      word-break: break-all;
+      overflow-wrap: anywhere;
     }
   </style>
 </head>


### PR DESCRIPTION
## Summary
- ensure the Bolívar 1936 history card metadata wraps long issuer strings within the layout
- apply the same metadata paragraph wrapping rules to the Copia Iatalicum 1918 card for consistency

## Testing
- not run (static HTML change)


------
https://chatgpt.com/codex/tasks/task_b_68d04fcbd3248326bd3c807b89fce8b2